### PR TITLE
Ensure that OpcTcpServerConnection is in opening state

### DIFF
--- a/src/org/opcfoundation/ua/transport/tcp/nio/OpcTcpServerConnection.java
+++ b/src/org/opcfoundation/ua/transport/tcp/nio/OpcTcpServerConnection.java
@@ -170,12 +170,12 @@ public class OpcTcpServerConnection extends AbstractServerConnection {
 					}
 				}
 		};
-		s.getStateMonitor().addStateListener(socketListener);
-		
-		s.getInputStream().createMonitor(8, inputListener);
-		
 		setState(CloseableObjectState.Opening);
-		
+
+		s.getStateMonitor().addStateListener(socketListener);
+		s.getInputStream().createMonitor(8, inputListener);
+
+
 		timeoutTimer = TimerUtil.schedule(
 				timer, timeout, 
 				StackUtils.getBlockingWorkExecutor(), 


### PR DESCRIPTION
Ensures that the `OpcTcpServerConnection` is in `Opening` state before
it starts receiving data.