### PR TITLE
Move jdk6 toolchain requirement into profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Maven needs to know where your JDK 6 installation is. To setup this create a fil
   </toolchain>
 </toolchains>
 ```
-If you have no need to have a Java 6 supported build artifact, then you can remove the maven-toolchains-plugin from the pom.xml before building the project.
+If you have no need to have a Java 6 supported build artifact, then you can run the build with the `jdk6` profile disabled.
 
 #### Compiling ####
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,29 +140,6 @@
   			</executions>
       </plugin>
       <!-- This plugin ensures we are actually building on JDK 6 -->
-      <!-- You need to create toolchains.xml in your .m2 folder -->
-      <plugin>
-      	<groupId>org.apache.maven.plugins</groupId>
-      	<artifactId>maven-toolchains-plugin</artifactId>
-      	<version>1.1</version>
-      	<executions>
-      		<execution>
-      		<id>check-toolchain</id>
-      		<phase>validate</phase>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-      	</executions>
-      	<configuration>
-      		<toolchains>
-      			<jdk>
-      				<version>1.6</version>
-      				<vendor>sun</vendor>
-      			</jdk>
-      		</toolchains>
-      	</configuration>
-      </plugin>
     </plugins>
     <pluginManagement>
     	<plugins>
@@ -247,4 +224,49 @@
   		<scope>test</scope>
   	</dependency>
   </dependencies>
+
+	<profiles>
+		<profile>
+			<id>jdk6</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<systemPropertyVariables>
+								<useJdk6Toolchain>true</useJdk6Toolchain>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+					<!-- This plugin ensures we are actually building on JDK 6 -->
+					<!-- You need to create toolchains.xml in your .m2 folder -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<version>1.1</version>
+						<executions>
+							<execution>
+								<id>check-toolchain</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>toolchain</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<toolchains>
+								<jdk>
+									<version>1.6</version>
+									<vendor>sun</vendor>
+								</jdk>
+							</toolchains>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/src/test/java/org/opcfoundation/ua/BuildHelper.java
+++ b/src/test/java/org/opcfoundation/ua/BuildHelper.java
@@ -1,0 +1,8 @@
+package org.opcfoundation.ua;
+
+public class BuildHelper {
+
+    public static boolean isJdk6Toolchain() {
+        return "true".equalsIgnoreCase(System.getProperty("useJdk6Toolchain"));
+    }
+}

--- a/src/test/java/org/opcfoundation/ua/unittests/TestStack.java
+++ b/src/test/java/org/opcfoundation/ua/unittests/TestStack.java
@@ -28,11 +28,16 @@
  * ======================================================================*/
 
 package org.opcfoundation.ua.unittests;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
 
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.opcfoundation.ua.BuildHelper;
 import org.opcfoundation.ua.application.Client;
 import org.opcfoundation.ua.application.Server;
 import org.opcfoundation.ua.application.TestStackService;
@@ -43,7 +48,6 @@ import org.opcfoundation.ua.common.ServiceResultException;
 import org.opcfoundation.ua.core.TestStackRequest;
 import org.opcfoundation.ua.core.TestStackResponse;
 import org.opcfoundation.ua.transport.AsyncResult;
-import org.opcfoundation.ua.transport.Endpoint;
 import org.opcfoundation.ua.transport.SecureChannel;
 import org.opcfoundation.ua.transport.security.BcCryptoProvider;
 import org.opcfoundation.ua.transport.security.HttpsSecurityPolicy;
@@ -52,13 +56,11 @@ import org.opcfoundation.ua.transport.security.SecurityMode;
 import org.opcfoundation.ua.utils.CryptoUtil;
 import org.opcfoundation.ua.utils.StackUtils;
 
-import junit.framework.TestCase;
-
 /**
  * Stress test & performance test using a loop-back server.
  *
  */
-public class TestStack extends TestCase {
+public class TestStack {
 
 	/** Timeout for a single test (Seconds) */
 	final static int ITERATION_TIMEOUT = 300;
@@ -66,7 +68,6 @@ public class TestStack extends TestCase {
 	String uri;
 	int keySize;
 	Server server;
-	Endpoint endpoint;
 	SecureChannel secureChannel;
 
 	// Fill array with debug data
@@ -78,6 +79,8 @@ public class TestStack extends TestCase {
 			data[i] = (byte) (r.nextInt(256) - 128);
 	}
 
+	@Test
+	@Ignore
 	public void ignoreTestHttps_TLS_1_2() throws Exception {
 		try {
 			_setupTest("https://localhost:6125/TestServer", HttpsSecurityPolicy.TLS_1_2, 4096);
@@ -87,7 +90,9 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHttps_TLS_1_0() throws Exception {
+		Assume.assumeTrue(BuildHelper.isJdk6Toolchain());
 		try {
 			_setupTest("https://localhost:6125/TestServer", HttpsSecurityPolicy.TLS_1_0, 2048);
 			executeTest();
@@ -96,6 +101,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testHttps_TLS_1_1() throws Exception {
 		try {
 			_setupTest("https://localhost:6125/TestServer", HttpsSecurityPolicy.TLS_1_1, 2048);
@@ -105,6 +111,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC128RSA15_SIGN_BC() throws Exception {
 		try {
 			CryptoUtil.setCryptoProvider(new BcCryptoProvider());
@@ -115,6 +122,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC128RSA15_SIGN_ENCRYPT_BC() throws Exception {
 		try {
 			CryptoUtil.setCryptoProvider(new BcCryptoProvider());
@@ -125,6 +133,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC128RSA15_SIGN_ENCRYPT_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC128RSA15_SIGN_ENCRYPT, 2048);
@@ -134,6 +143,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC128RSA15_SIGN_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC128RSA15_SIGN, 2048);
@@ -143,6 +153,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256_SIGN_ENCRYPT_BC() throws Exception {
 		try {
 			CryptoUtil.setCryptoProvider(new BcCryptoProvider());
@@ -154,6 +165,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256_SIGN_ENCRYPT_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC256_SIGN_ENCRYPT, 2048);
@@ -163,6 +175,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256_SIGN_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC256_SIGN, 2048);
@@ -172,6 +185,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256SHA256_SIGN_ENCRYPT_BC() throws Exception {
 		try {
 			CryptoUtil.setCryptoProvider(new BcCryptoProvider());
@@ -183,6 +197,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256SHA256_SIGN_ENCRYPT_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC256SHA256_SIGN_ENCRYPT, 4096);
@@ -192,6 +207,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_BASIC256SHA256_SIGN_JCE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.BASIC256SHA256_SIGN, 4096);
@@ -201,6 +217,7 @@ public class TestStack extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOPC_TCP_NONE() throws Exception {
 		try {
 			_setupTest("opc.tcp://localhost:6125/TestServer", SecurityMode.NONE, 2048);


### PR DESCRIPTION
By moving the jdk6 toolchain requirement into a profile that is active
by default, it can be skipped without manually removing the plugin from
the `pom.xml`.