### PR TITLE
Fix potential Bad_DecodingError in XMLDecoder

### DIFF
--- a/src/main/java/org/opcfoundation/ua/encoding/xml/XmlDecoder.java
+++ b/src/main/java/org/opcfoundation/ua/encoding/xml/XmlDecoder.java
@@ -139,6 +139,9 @@ public class XmlDecoder implements IDecoder {
 
 	@Override
 	public <T> T get(String fieldName, Class<T> clazz) throws DecodingException {
+		if(beginFieldSafe(fieldName, true)) {
+			endField(fieldName);
+		}
 		return null;
 	}
 


### PR DESCRIPTION
For some reason, the `XMLDecoder.get` method simply returns `null`, and
even does not advance the xml parser to the expected element. This can
cause later decoding to fail with `Bad_DecodingError` since the xml
parser is not at the expected element.

Fixes #55 