### PR TITLE
Fix getNextTimeoutingPendingRequest() in SecureChannelTcp.java

### DIFF
--- a/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
+++ b/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
@@ -543,7 +543,7 @@ public class SecureChannelTcp implements IMessageListener, IConnectionListener, 
 			if (next > req.timeoutTime) {
 				next = req.timeoutTime;
 				result = req;
-				break;
+	//			break;
 			}
 		}
 		return result;


### PR DESCRIPTION
The break in the for loop will result in finding only the first request with a timeout and not necessarily the one with the NEXT timeout time.

Requests may have been created with differing timeout intervals and a request added later with a shorter timeout may have an earlier timeout time than a request added before that. So even if the map would be presenting the requests with ascending requestId, the first request with a timeout may not be the one with the NEXT timeout time. Removing the break will make sure, all requests are checked and the one with the lowest timeout time is returned.

Leaving the break in the for loop may have requests time out too late, possibly influencing the client's timing in a negative and unforeseen way.