### PR TITLE
ExpandedNodeId - Typo in toString, change to parse, few Tests

### DIFF
--- a/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
+++ b/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
@@ -423,14 +423,14 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 	@Override
 	public String toString() {
 		try {
-			String srvPart = !isLocal() ? "srv="+serverIndex+";" : "";
+			String svrPart = !isLocal() ? "svr="+serverIndex+";" : "";
 			String nsPart = namespaceUri!=null ? "nsu="+URLEncoder.encode(namespaceUri, "ISO8859-1")+";" : namespaceIndex>0 ? "ns="+namespaceIndex+";" : "";
-			if (type == IdType.Numeric) return srvPart+nsPart+"i="+value;
-			if (type == IdType.String) return srvPart+nsPart+"s="+value;
-			if (type == IdType.Guid) return srvPart+nsPart+"g="+value;
+			if (type == IdType.Numeric) return svrPart+nsPart+"i="+value;
+			if (type == IdType.String) return svrPart+nsPart+"s="+value;
+			if (type == IdType.Guid) return svrPart+nsPart+"g="+value;
 			if (type == IdType.Opaque) {
-				if (value==null) return srvPart+nsPart+"b=null";
-				return srvPart+nsPart+"b="+new String( CryptoUtil.base64Encode(((ByteString)value).getValue()) );
+				if (value==null) return svrPart+nsPart+"b=null";
+				return svrPart+nsPart+"b="+new String( CryptoUtil.base64Encode(((ByteString)value).getValue()) );
 			}
 		} catch (UnsupportedEncodingException e) {
 		}

--- a/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
+++ b/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
@@ -94,6 +94,10 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 			} else
 				throwExpandedNodeIdCastException(s);
 		}
+		//ns and nsu skipped
+		if(returnable == null) {
+			returnable = new ExpandedNodeId(UnsignedInteger.valueOf(svrIndex), nsIndex, nodeIdValue.getValue());
+		}
 		return returnable;
 	}
 	/**

--- a/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
+++ b/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
@@ -13,7 +13,6 @@
 package org.opcfoundation.ua.builtintypes;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.UUID;
 
@@ -53,8 +52,6 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 
 	/** Identifier of "NodeId" in UA AddressSpace */
 	public static final NodeId ID = Identifiers.ExpandedNodeId;
-	
-	private static final String XML_ENCODING = "ISO8859-1";
 
 	/**
 	 * Check if nodeId is null or a NullNodeId.
@@ -103,16 +100,6 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 		}
 		return returnable;
 	}
-	
-	public static ExpandedNodeId parseXmlEncodedExpandedNodeId(String s) throws UnsupportedEncodingException {
-		final ExpandedNodeId parsed = parseExpandedNodeId(s);
-		if(parsed.getNamespaceUri() != null) {
-			String decoded = URLDecoder.decode(parsed.namespaceUri, XML_ENCODING);
-			return new ExpandedNodeId(parsed.serverIndex, decoded, parsed.value);
-		}
-		return parsed;
-	}
-	
 	/**
 	 * @param s
 	 * @param parts
@@ -439,30 +426,18 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 	/** {@inheritDoc} */
 	@Override
 	public String toString() {
-			String svrPart = !isLocal() ? "svr=" + serverIndex + ";" : "";
-			String nsPart = namespaceUri != null ? "nsu=" + namespaceUri + ";"
-					: namespaceIndex > 0 ? "ns=" + namespaceIndex + ";" : "";
-			switch (type) {
-			case Guid:
-				return svrPart + nsPart + "g=" + value;
-			case Numeric:
-				return svrPart + nsPart + "i=" + value;
-			case Opaque:
-				if (value == null)
-					return svrPart + nsPart + "b=null";
-				return svrPart + nsPart + "b=" + new String(CryptoUtil.base64Encode(((ByteString) value).getValue()));
-			case String:
-				return svrPart + nsPart + "s=" + value;
-			default:
-				return "error";
+		try {
+			String svrPart = !isLocal() ? "svr="+serverIndex+";" : "";
+			String nsPart = namespaceUri!=null ? "nsu="+URLEncoder.encode(namespaceUri, "ISO8859-1")+";" : namespaceIndex>0 ? "ns="+namespaceIndex+";" : "";
+			if (type == IdType.Numeric) return svrPart+nsPart+"i="+value;
+			if (type == IdType.String) return svrPart+nsPart+"s="+value;
+			if (type == IdType.Guid) return svrPart+nsPart+"g="+value;
+			if (type == IdType.Opaque) {
+				if (value==null) return svrPart+nsPart+"b=null";
+				return svrPart+nsPart+"b="+new String( CryptoUtil.base64Encode(((ByteString)value).getValue()) );
 			}
-	}
-
-	public String getXMLEncodedString() throws UnsupportedEncodingException {
-		String plain = toString();
-		if (namespaceUri != null) {
-			return plain.replace(namespaceUri, URLEncoder.encode(namespaceUri, XML_ENCODING));
+		} catch (UnsupportedEncodingException e) {
 		}
-		return plain;
+		return "error";
 	}
 }

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -19,18 +19,23 @@ public class ExpandedNodeIdTest {
 	}
 
 	@Test
-	public void parseServerIndex() {
+	public void parseServerIndexByStringComposition() {
 		final int namespaceIndex = 1;
 		final int intValue = 0;
 		final UnsignedInteger serverIndex = UnsignedInteger.valueOf(1);
-		// toString
 		ExpandedNodeId serverNsIndex = new ExpandedNodeId(serverIndex, namespaceIndex, intValue);
-		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverNsIndex.toString());
-		assertEquals(serverNsIndex, parsed);
-		// string composed
+		// composition
 		String stringComposition = "svr=" + serverIndex + ";" + "ns=" + namespaceIndex + ";i=" + intValue;
 		ExpandedNodeId parsedComposition = ExpandedNodeId.parseExpandedNodeId(stringComposition);
 		assertEquals(serverNsIndex, parsedComposition);
+	}
+
+	@Test
+	public void parseServerIndexByToString() {
+		ExpandedNodeId serverNsIndex = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		// toString
+		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverNsIndex.toString());
+		assertEquals(serverNsIndex, parsed);
 	}
 
 	@Test
@@ -45,27 +50,45 @@ public class ExpandedNodeIdTest {
 	}
 
 	@Test
-	public void equalsServerIndexes() {
+	public void equalsSameServerIndex() {
 		ExpandedNodeId pivotServerIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
-		//
 		ExpandedNodeId serverIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
 		assertEquals(pivotServerIndex1, serverIndex1);
-		//
+	}
+
+	@Test
+	public void equalsDifferentServerIndex() {
+		ExpandedNodeId pivotServerIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
 		ExpandedNodeId serverIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(2), 0, 0);
 		assertNotEquals(pivotServerIndex1, serverIndex2);
 	}
 
 	@Test
-	public void equalsNamespaceIndixes() {
-		ExpandedNodeId pivotNsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
-		// equal namespaces
+	public void equalsSameNamespaceIndex() {
+		ExpandedNodeId nsIndex1a = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
 		ExpandedNodeId nsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
-		assertEquals(pivotNsIndex1, nsIndex1);
-		// different ns
+		assertEquals(nsIndex1a, nsIndex1);
+	}
+
+	@Test
+	public void equalsDifferentNamespaceIndex() {
+		ExpandedNodeId nsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
 		ExpandedNodeId nsIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 2, 0);
-		assertNotEquals(pivotNsIndex1, nsIndex2);
-		// ns to uri
+		assertNotEquals(nsIndex1, nsIndex2);
+	}
+
+	@Test
+	public void equalsNamespaceIndexToURI() {
+		ExpandedNodeId index = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
 		ExpandedNodeId uri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
-		assertNotEquals(pivotNsIndex1, uri);
+		assertNotEquals(index, uri);
+	}
+
+	@Test
+	public void equalsDifferentNamespaceURI() {
+		ExpandedNodeId uriDI = new ExpandedNodeId("http://opcfoundation.org/UA/DI/", 0);
+		ExpandedNodeId uriUA = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		assertNotEquals(uriUA, uriDI);
+
 	}
 }

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -17,6 +17,17 @@ public class ExpandedNodeIdTest {
 		ExpandedNodeId nullUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, UnsignedInteger.valueOf(0));
 		Assert.assertTrue(nullUri.isNullNodeId());
 	}
+	
+	@Test
+	public void parseServerIndexWithtoutNamespaceComponent() {
+		final int intValue = 0;
+		final UnsignedInteger serverIndex = UnsignedInteger.valueOf(1);
+		// parse without nsu and ns
+		ExpandedNodeId namespaceIndex0 = new ExpandedNodeId(serverIndex, 0, intValue);
+		String stringWithoutMiddlePart = "svr=" + serverIndex + ";i=" + intValue;
+		ExpandedNodeId parsedWithoutMiddlePart = ExpandedNodeId.parseExpandedNodeId(stringWithoutMiddlePart);
+		assertEquals(namespaceIndex0, parsedWithoutMiddlePart);
+	}
 
 	@Test
 	public void parseServerIndexByStringComposition() {

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -17,7 +17,7 @@ public class ExpandedNodeIdTest {
 		ExpandedNodeId nullUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, UnsignedInteger.valueOf(0));
 		Assert.assertTrue(nullUri.isNullNodeId());
 	}
-	
+
 	@Test
 	public void parseServerIndexWithtoutNamespaceComponent() {
 		final int intValue = 0;
@@ -48,6 +48,12 @@ public class ExpandedNodeIdTest {
 		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverNsIndex.toString());
 		assertEquals(serverNsIndex, parsed);
 	}
+	
+	@Test
+	public void parseValueOnly() {
+		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId("i=0");
+		assertEquals(new ExpandedNodeId(UnsignedInteger.valueOf(0), 0, 0), parsed);
+	}
 
 	@Test
 	public void parseNamespaceUri() {
@@ -58,6 +64,14 @@ public class ExpandedNodeIdTest {
 		String stringComposition = "nsu=" + namespaceURI + ";i=" + intValue;
 		ExpandedNodeId parsedComposition = ExpandedNodeId.parseExpandedNodeId(stringComposition);
 		assertEquals(serverUri, parsedComposition);
+	}
+
+	@Test
+	public void parseNamespaceUriFromToString() {
+		ExpandedNodeId serverUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		// toString
+		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverUri.toString());
+		assertEquals(serverUri, parsed);
 	}
 
 	@Test

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -1,11 +1,11 @@
 package org.opcfoundation.ua.builtintypes;
 
-import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.opcfoundation.ua.common.NamespaceTable;
-
 
 public class ExpandedNodeIdTest {
 
@@ -18,12 +18,54 @@ public class ExpandedNodeIdTest {
 		Assert.assertTrue(nullUri.isNullNodeId());
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@Test
+	public void parseServerIndex() {
+		final int namespaceIndex = 1;
+		final int intValue = 0;
+		final UnsignedInteger serverIndex = UnsignedInteger.valueOf(1);
+		// toString
+		ExpandedNodeId serverNsIndex = new ExpandedNodeId(serverIndex, namespaceIndex, intValue);
+		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverNsIndex.toString());
+		assertEquals(serverNsIndex, parsed);
+		// string composed
+		String stringComposition = "svr=" + serverIndex + ";" + "ns=" + namespaceIndex + ";i=" + intValue;
+		ExpandedNodeId parsedComposition = ExpandedNodeId.parseExpandedNodeId(stringComposition);
+		assertEquals(serverNsIndex, parsedComposition);
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@Test
+	public void parseNamespaceUri() {
+		final String namespaceURI = NamespaceTable.OPCUA_NAMESPACE;
+		final int intValue = 0;
+		ExpandedNodeId serverUri = new ExpandedNodeId(namespaceURI, intValue);
+		// string composed
+		String stringComposition = "nsu=" + namespaceURI + ";i=" + intValue;
+		ExpandedNodeId parsedComposition = ExpandedNodeId.parseExpandedNodeId(stringComposition);
+		assertEquals(serverUri, parsedComposition);
 	}
 
+	@Test
+	public void equalsServerIndexes() {
+		ExpandedNodeId pivotServerIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
+		//
+		ExpandedNodeId serverIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
+		assertEquals(pivotServerIndex1, serverIndex1);
+		//
+		ExpandedNodeId serverIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(2), 0, 0);
+		assertNotEquals(pivotServerIndex1, serverIndex2);
+	}
+
+	@Test
+	public void equalsNamespaceIndixes() {
+		ExpandedNodeId pivotNsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		// equal namespaces
+		ExpandedNodeId nsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		assertEquals(pivotNsIndex1, nsIndex1);
+		// different ns
+		ExpandedNodeId nsIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 2, 0);
+		assertNotEquals(pivotNsIndex1, nsIndex2);
+		// ns to uri
+		ExpandedNodeId uri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		assertNotEquals(pivotNsIndex1, uri);
+	}
 }

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -17,7 +17,7 @@ public class ExpandedNodeIdTest {
 		ExpandedNodeId nullUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, UnsignedInteger.valueOf(0));
 		Assert.assertTrue(nullUri.isNullNodeId());
 	}
-
+	
 	@Test
 	public void parseServerIndexWithtoutNamespaceComponent() {
 		final int intValue = 0;
@@ -48,12 +48,6 @@ public class ExpandedNodeIdTest {
 		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverNsIndex.toString());
 		assertEquals(serverNsIndex, parsed);
 	}
-	
-	@Test
-	public void parseValueOnly() {
-		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId("i=0");
-		assertEquals(new ExpandedNodeId(UnsignedInteger.valueOf(0), 0, 0), parsed);
-	}
 
 	@Test
 	public void parseNamespaceUri() {
@@ -64,14 +58,6 @@ public class ExpandedNodeIdTest {
 		String stringComposition = "nsu=" + namespaceURI + ";i=" + intValue;
 		ExpandedNodeId parsedComposition = ExpandedNodeId.parseExpandedNodeId(stringComposition);
 		assertEquals(serverUri, parsedComposition);
-	}
-
-	@Test
-	public void parseNamespaceUriFromToString() {
-		ExpandedNodeId serverUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
-		// toString
-		ExpandedNodeId parsed = ExpandedNodeId.parseExpandedNodeId(serverUri.toString());
-		assertEquals(serverUri, parsed);
 	}
 
 	@Test


### PR DESCRIPTION
1. Typo in toString:  "srv=" is specified as "svr=" in specification and used so in parseExpandedNodeId
2. ExpandedNodeId did not parse value-only (e.g. "i=1") and ids without namespace part (e.g. "svr=1;i=1")
3. Tests for changes and some for equals