### PR TITLE
Feature/gh 136 update to 1.04 resource files

### DIFF
--- a/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
+++ b/src/main/java/org/opcfoundation/ua/builtintypes/ExpandedNodeId.java
@@ -12,14 +12,11 @@
 
 package org.opcfoundation.ua.builtintypes;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.UUID;
 
 import org.opcfoundation.ua.common.NamespaceTable;
 import org.opcfoundation.ua.core.IdType;
 import org.opcfoundation.ua.core.Identifiers;
-import org.opcfoundation.ua.utils.CryptoUtil;
 import org.opcfoundation.ua.utils.ObjectUtils;
 
 
@@ -62,60 +59,7 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 	public static boolean isNull(ExpandedNodeId nodeId) {
 		return (nodeId == null) || nodeId.isNullNodeId();
 	}
-	/**
-	 * <p>parseExpandedNodeId.</p>
-	 *
-	 * @param s a {@link java.lang.String} object.
-	 * @return a {@link org.opcfoundation.ua.builtintypes.ExpandedNodeId} object.
-	 */
-	public static ExpandedNodeId parseExpandedNodeId(String s) {
-		String[] parts = s.split(";");
-		assertExpandedNodeIdParts(s, parts, 1);
-
-		int svrIndex = 0;
-		int nsIndex = 0;
-		NodeId nodeIdValue = NodeId.parseNodeId(parts[parts.length - 1]);
-		ExpandedNodeId returnable = null;
-		for (int i = 0; i < parts.length - 1; i++) {
-			String[] subParts = parts[i].split("=");
-			assertExpandedNodeIdParts(s, subParts, 2);
-			if (subParts[0].equalsIgnoreCase("svr"))
-				svrIndex = Integer.parseInt(subParts[1]);
-			else if (subParts[0].equalsIgnoreCase("ns")) {
-				nsIndex = Integer.parseInt(subParts[1]);
-				returnable = new ExpandedNodeId(
-						UnsignedInteger.valueOf(svrIndex), nsIndex,
-						nodeIdValue.getValue());
-			} else if (subParts[0].equalsIgnoreCase("nsu")) {
-				String ns = subParts[1];
-				returnable = new ExpandedNodeId(
-						UnsignedInteger.valueOf(svrIndex), ns,
-						nodeIdValue.getValue());
-			} else
-				throwExpandedNodeIdCastException(s);
-		}
-		return returnable;
-	}
-	/**
-	 * @param s
-	 * @param parts
-	 * @param n
-	 * @throws ClassCastException
-	 */
-	private static void assertExpandedNodeIdParts(String s, String[] parts, final int n)
-			throws ClassCastException {
-		if (parts.length < n)
-			throwExpandedNodeIdCastException(s);
-	}
-	/**
-	 * @param s
-	 * @throws ClassCastException
-	 */
-	private static void throwExpandedNodeIdCastException(String s)
-			throws ClassCastException {
-		throw new ClassCastException("String is not a valid ExpandedNodeId: "
-				+ s);
-	}
+	
 	final IdType type;
 
 	final int namespaceIndex;
@@ -417,23 +361,5 @@ public final class ExpandedNodeId implements Comparable<ExpandedNodeId>{
 			nsIdx = namespaceIndex;
 		}
 		return NodeId.get(type, nsIdx, value).isNullNodeId();
-	}
-
-	/** {@inheritDoc} */
-	@Override
-	public String toString() {
-		try {
-			String srvPart = !isLocal() ? "srv="+serverIndex+";" : "";
-			String nsPart = namespaceUri!=null ? "nsu="+URLEncoder.encode(namespaceUri, "ISO8859-1")+";" : namespaceIndex>0 ? "ns="+namespaceIndex+";" : "";
-			if (type == IdType.Numeric) return srvPart+nsPart+"i="+value;
-			if (type == IdType.String) return srvPart+nsPart+"s="+value;
-			if (type == IdType.Guid) return srvPart+nsPart+"g="+value;
-			if (type == IdType.Opaque) {
-				if (value==null) return srvPart+nsPart+"b=null";
-				return srvPart+nsPart+"b="+new String( CryptoUtil.base64Encode(((ByteString)value).getValue()) );
-			}
-		} catch (UnsupportedEncodingException e) {
-		}
-		return "error";
 	}
 }

--- a/src/main/java/org/opcfoundation/ua/encoding/xml/XmlDecoder.java
+++ b/src/main/java/org/opcfoundation/ua/encoding/xml/XmlDecoder.java
@@ -12,6 +12,7 @@
 package org.opcfoundation.ua.encoding.xml;
 
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -52,6 +53,7 @@ import org.opcfoundation.ua.encoding.DecodingException;
 import org.opcfoundation.ua.encoding.EncoderContext;
 import org.opcfoundation.ua.encoding.IDecoder;
 import org.opcfoundation.ua.encoding.IEncodeable;
+import org.opcfoundation.ua.encoding.xml.helpers.XmlExpandedNodeId;
 import org.opcfoundation.ua.utils.CryptoUtil;
 import org.opcfoundation.ua.utils.MultiDimensionArrayUtils;
 import org.opcfoundation.ua.utils.XMLFactoryCache;
@@ -997,7 +999,7 @@ public class XmlDecoder implements IDecoder {
 		//			return null;
 		//		}
 
-		return (T[]) encodeables.toArray((T[])Array.newInstance(encodeableClass, encodeables.size()));
+		return encodeables.toArray((T[])Array.newInstance(encodeableClass, encodeables.size()));
 	}
 
 	/**
@@ -1151,8 +1153,11 @@ public class XmlDecoder implements IDecoder {
 
 		if (beginFieldSafe(fieldName, true))
 		{
-			value = ExpandedNodeId.parseExpandedNodeId(getString("Identifier"));
-
+			try {
+				value = XmlExpandedNodeId.parse(getString("Identifier"));	
+			}catch(UnsupportedEncodingException e) {
+				throw new DecodingException(e.getMessage()+" encoding is not supported but required for decoding");
+			}
 			endField(fieldName);
 		}
 
@@ -1177,6 +1182,8 @@ public class XmlDecoder implements IDecoder {
 
 		return value;
 	}
+	
+	
 
 	/// <summary>
 	/// Reads an ExpandedNodeId array from the stream.

--- a/src/main/java/org/opcfoundation/ua/encoding/xml/helpers/XmlExpandedNodeId.java
+++ b/src/main/java/org/opcfoundation/ua/encoding/xml/helpers/XmlExpandedNodeId.java
@@ -1,0 +1,107 @@
+package org.opcfoundation.ua.encoding.xml.helpers;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+
+import org.opcfoundation.ua.builtintypes.ByteString;
+import org.opcfoundation.ua.builtintypes.ExpandedNodeId;
+import org.opcfoundation.ua.builtintypes.NodeId;
+import org.opcfoundation.ua.builtintypes.UnsignedInteger;
+import org.opcfoundation.ua.utils.CryptoUtil;
+
+public class XmlExpandedNodeId {
+
+	/**
+	 * Latin alphabet No.1
+	 */
+	public static final String NSU_XML_ENCODING = "ISO8859-1";
+
+	/**
+	 * <p>
+	 * parseExpandedNodeId.
+	 * </p>
+	 *
+	 * @param s
+	 *            a {@link java.lang.String} object.
+	 * @return a {@link org.opcfoundation.ua.builtintypes.ExpandedNodeId} object.
+	 * @throws UnsupportedEncodingException
+	 */
+	public static ExpandedNodeId parse(String s) throws UnsupportedEncodingException {
+		String[] parts = s.split(";");
+		assertExpandedNodeIdParts(s, parts, 1);
+
+		int svrIndex = 0;
+		int nsIndex = 0;
+		NodeId nodeIdValue = NodeId.parseNodeId(parts[parts.length - 1]);
+		ExpandedNodeId returnable = null;
+		for (int i = 0; i < parts.length - 1; i++) {
+			String[] subParts = parts[i].split("=");
+			assertExpandedNodeIdParts(s, subParts, 2);
+			if (subParts[0].equalsIgnoreCase("svr"))
+				svrIndex = Integer.parseInt(subParts[1]);
+			else if (subParts[0].equalsIgnoreCase("ns")) {
+				nsIndex = Integer.parseInt(subParts[1]);
+				returnable = new ExpandedNodeId(UnsignedInteger.valueOf(svrIndex), nsIndex, nodeIdValue.getValue());
+			} else if (subParts[0].equalsIgnoreCase("nsu")) {
+				String ns = subParts[1];
+				ns = URLDecoder.decode(ns, NSU_XML_ENCODING);
+				returnable = new ExpandedNodeId(UnsignedInteger.valueOf(svrIndex), ns, nodeIdValue.getValue());
+			} else
+				throwExpandedNodeIdCastException(s);
+		}
+		// ns and nsu skipped
+		if (returnable == null) {
+			returnable = new ExpandedNodeId(UnsignedInteger.valueOf(svrIndex), nsIndex, nodeIdValue.getValue());
+		}
+		return returnable;
+	}
+
+	public static String composeString(ExpandedNodeId eNodeId) throws UnsupportedEncodingException {
+		String svrPart = !eNodeId.isLocal() ? "svr=" + eNodeId.getServerIndex() + ";" : "";
+		String nsPart = getNsPart(eNodeId);
+
+		Object value = eNodeId.getValue();
+		switch (eNodeId.getIdType()) {
+		case Numeric:
+			return svrPart + nsPart + "i=" + value;
+		case Guid:
+			return svrPart + nsPart + "g=" + value;
+		case Opaque:
+			if (value == null)
+				return svrPart + nsPart + "b=null";
+			return svrPart + nsPart + "b=" + new String(CryptoUtil.base64Encode(((ByteString) value).getValue()));
+		case String:
+			return svrPart + nsPart + "s=" + value;
+		default:
+			return "error";
+		}
+	}
+
+	private static String getNsPart(ExpandedNodeId eNodeId) throws UnsupportedEncodingException {
+		String namespaceUri = eNodeId.getNamespaceUri();
+		int namespaceIndex = eNodeId.getNamespaceIndex();
+		return namespaceUri != null ? "nsu=" + URLEncoder.encode(namespaceUri, "ISO8859-1") + ";"
+				: namespaceIndex > 0 ? "ns=" + namespaceIndex + ";" : "";
+	}
+
+	/**
+	 * @param s
+	 * @param parts
+	 * @param n
+	 * @throws ClassCastException
+	 */
+	private static void assertExpandedNodeIdParts(String s, String[] parts, final int n) throws ClassCastException {
+		if (parts.length < n)
+			throwExpandedNodeIdCastException(s);
+	}
+
+	/**
+	 * @param s
+	 * @throws ClassCastException
+	 */
+	private static void throwExpandedNodeIdCastException(String s) throws ClassCastException {
+		throw new ClassCastException("String is not a valid ExpandedNodeId: " + s);
+	}
+
+}

--- a/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/builtintypes/ExpandedNodeIdTest.java
@@ -1,29 +1,63 @@
 package org.opcfoundation.ua.builtintypes;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.opcfoundation.ua.common.NamespaceTable;
-
 
 public class ExpandedNodeIdTest {
 
 	@Test
 	public void nullTest() {
 		ExpandedNodeId nullIdx = new ExpandedNodeId(null, 0, UnsignedInteger.valueOf(0));
-		Assert.assertTrue(nullIdx.isNullNodeId());
-
+		assertTrue(nullIdx.isNullNodeId());
 		ExpandedNodeId nullUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, UnsignedInteger.valueOf(0));
-		Assert.assertTrue(nullUri.isNullNodeId());
+		assertTrue(nullUri.isNullNodeId());
 	}
 
-	@Before
-	public void setUp() throws Exception {
+	@Test
+	public void equalsSameServerIndex() {
+		ExpandedNodeId pivotServerIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
+		ExpandedNodeId serverIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
+		assertEquals(pivotServerIndex1, serverIndex1);
+
+	}
+	
+	@Test
+	public void equalsDifferentServerIndex() {
+		ExpandedNodeId pivotServerIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 0, 0);
+		ExpandedNodeId serverIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(2), 0, 0);
+		assertNotEquals(pivotServerIndex1, serverIndex2);
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@Test
+	public void equalsSameNamespaceIndex() {
+		ExpandedNodeId nsIndex1a = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		ExpandedNodeId nsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		assertEquals(nsIndex1a, nsIndex1);
+	}
+
+	@Test
+	public void equalsDifferentNamespaceIndex() {
+		ExpandedNodeId nsIndex1 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		ExpandedNodeId nsIndex2 = new ExpandedNodeId(UnsignedInteger.valueOf(1), 2, 0);
+		assertNotEquals(nsIndex1, nsIndex2);
+	}
+
+	@Test
+	public void equalsNamespaceIndexToURI() {
+		ExpandedNodeId index = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		ExpandedNodeId uri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		assertNotEquals(index, uri);
+	}
+
+	@Test
+	public void equalsDifferentNamespaceURI() {
+		ExpandedNodeId uriDI = new ExpandedNodeId("http://opcfoundation.org/UA/DI/", 0);
+		ExpandedNodeId uriUA = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		assertNotEquals(uriUA, uriDI);
 	}
 
 }

--- a/src/test/java/org/opcfoundation/ua/encoding/xml/XmlExpandedNodeIdTest.java
+++ b/src/test/java/org/opcfoundation/ua/encoding/xml/XmlExpandedNodeIdTest.java
@@ -1,0 +1,71 @@
+package org.opcfoundation.ua.encoding.xml;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+
+import org.junit.Test;
+import org.opcfoundation.ua.builtintypes.ExpandedNodeId;
+import org.opcfoundation.ua.builtintypes.UnsignedInteger;
+import org.opcfoundation.ua.common.NamespaceTable;
+import org.opcfoundation.ua.encoding.xml.helpers.XmlExpandedNodeId;
+
+public class XmlExpandedNodeIdTest {
+
+	@Test
+	public void parseServerIndexWithtoutNamespaceComponent() throws UnsupportedEncodingException {
+		final int intValue = 0;
+		final UnsignedInteger serverIndex = UnsignedInteger.valueOf(1);
+		// parse without nsu and ns
+		ExpandedNodeId namespaceIndex0 = new ExpandedNodeId(serverIndex, 0, intValue);
+		String stringWithoutMiddlePart = "svr=" + serverIndex + ";i=" + intValue;
+		ExpandedNodeId parsedWithoutMiddlePart = XmlExpandedNodeId.parse(stringWithoutMiddlePart);
+		assertEquals(namespaceIndex0, parsedWithoutMiddlePart);
+	}
+
+	@Test
+	public void parseValueOnly() throws UnsupportedEncodingException {
+		ExpandedNodeId parsed = XmlExpandedNodeId.parse("i=0");
+		assertEquals(new ExpandedNodeId(UnsignedInteger.valueOf(0), 0, 0), parsed);
+	}
+
+	@Test
+	public void parseServerIndexByStringComposition() throws UnsupportedEncodingException {
+		final int namespaceIndex = 1;
+		final int intValue = 0;
+		final UnsignedInteger serverIndex = UnsignedInteger.valueOf(1);
+		ExpandedNodeId serverNsIndex = new ExpandedNodeId(serverIndex, namespaceIndex, intValue);
+		// composition
+		String stringComposition = "svr=" + serverIndex + ";" + "ns=" + namespaceIndex + ";i=" + intValue;
+		ExpandedNodeId parsedComposition = XmlExpandedNodeId.parse(stringComposition);
+		assertEquals(serverNsIndex, parsedComposition);
+	}
+
+	@Test
+	public void parseServerIndexByToString() throws UnsupportedEncodingException {
+		ExpandedNodeId serverNsIndex = new ExpandedNodeId(UnsignedInteger.valueOf(1), 1, 0);
+		// toString
+		ExpandedNodeId parsed = XmlExpandedNodeId.parse(XmlExpandedNodeId.composeString(serverNsIndex));
+		assertEquals(serverNsIndex, parsed);
+	}
+
+	@Test
+	public void parseNamespaceUri() throws UnsupportedEncodingException {
+		final String namespaceURI = NamespaceTable.OPCUA_NAMESPACE;
+		final int intValue = 0;
+		ExpandedNodeId serverUri = new ExpandedNodeId(namespaceURI, intValue);
+		// string composed
+		String stringComposition = "nsu=" + namespaceURI + ";i=" + intValue;
+		ExpandedNodeId parsedComposition = XmlExpandedNodeId.parse(stringComposition);
+		assertEquals(serverUri, parsedComposition);
+	}
+
+	@Test
+	public void parseNamespaceUriFromToString() throws UnsupportedEncodingException {
+		ExpandedNodeId serverUri = new ExpandedNodeId(NamespaceTable.OPCUA_NAMESPACE, 0);
+		// toString
+		ExpandedNodeId parsed = XmlExpandedNodeId.parse(XmlExpandedNodeId.composeString(serverUri));
+		assertEquals(serverUri, parsed);
+	}
+
+}


### PR DESCRIPTION
**Breaking Change**
Extracted ExpandedNodeId.parse and toString (that included defacto nsu part xml encode) to encodings

- specifically to encodigs.xml.helpers.XmlExpandedNodeId parse & composeString(ExpandedNodeId)
- naturally also changed the reference of XmlDecoder to this new helper class (introduced for seperation of concern)
- moved tests for parse/composeString and (re-) added tests for encoding/decoding of nsu

I hope this is the way intended for branch/pull [otherwise I wouldn't know how to introduce a new branch for this change that could be pulled]
If this is not the intended way (rejected) I could still open this as an Issue if that is better