### PR TITLE
Fixed NullPointerException on error recovery reconnect.

### DIFF
--- a/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
+++ b/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
@@ -1145,7 +1145,11 @@ public class SecureChannelTcp implements IMessageListener, IConnectionListener, 
 			}
 			
 			try {
-				logger.debug("{}: Error recovery reconnect", secureChannelId);				
+				logger.debug("{}: Error recovery reconnect", secureChannelId);
+			
+				if (getTransportChannel()==null)
+					throw new ServiceResultException(StatusCodes.Bad_SecureChannelClosed);
+				
 				getTransportChannel().open();
 				createSecureChannel(true);
 				


### PR DESCRIPTION
Now throws exception Bad_SecureChannelClosed if secure channel is null after it was closed.