### PR TITLE
Fixed NullPointerException in error recovery reconnect

### DIFF
--- a/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
+++ b/src/main/java/org/opcfoundation/ua/transport/tcp/io/SecureChannelTcp.java
@@ -1146,6 +1146,10 @@ public class SecureChannelTcp implements IMessageListener, IConnectionListener, 
 			
 			try {
 				logger.debug("{}: Error recovery reconnect", secureChannelId);				
+				
+				if (getTransportChannel()==null)
+					throw new ServiceResultException(StatusCodes.Bad_SecureChannelClosed);
+				
 				getTransportChannel().open();
 				createSecureChannel(true);
 				


### PR DESCRIPTION
The NullPointerException happened, when the secure channel was actually
closed and getSecureChannel() returned null.

Now a ServiceResultException is thrown with result code
Bad_SecureChannelClosed.